### PR TITLE
44 fix javadoc for new classes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,6 @@
 The MIT License
 
-Copyright (c) 2024, Alex Schiff (alex.schiff@protonmail.com) and
-Jamal Khaffaf (jamalkhaffaf@proton.me).
+Copyright (c) 2024, Alex Schiff (alex.schiff@protonmail.com).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/k-random-bean-validation/pom.xml
+++ b/k-random-bean-validation/pom.xml
@@ -46,14 +46,6 @@
                 <role>Lead developer</role>
             </roles>
         </developer>
-        <developer>
-            <id>jamalkhaffaf</id>
-            <name>Jamal Khaffaf</name>
-            <url>https://github.com/jamalkhaffaf</url>
-            <roles>
-                <role>Core developer</role>
-            </roles>
-        </developer>
     </developers>
 
     <dependencies>

--- a/k-random-bean-validation/src/main/java/io/github/krandom/validation/AbstractNumberBaseAnnotationHandler.java
+++ b/k-random-bean-validation/src/main/java/io/github/krandom/validation/AbstractNumberBaseAnnotationHandler.java
@@ -32,7 +32,6 @@ import java.util.Random;
 
 /**
  * @author dadiyang
- * @since 4.3
  */
 public abstract class AbstractNumberBaseAnnotationHandler
     implements BeanValidationAnnotationHandler {

--- a/k-random-bean-validation/src/main/java/io/github/krandom/validation/AbstractTemporalBaseAnnotationHandler.java
+++ b/k-random-bean-validation/src/main/java/io/github/krandom/validation/AbstractTemporalBaseAnnotationHandler.java
@@ -12,6 +12,9 @@ import java.time.chrono.ThaiBuddhistDate;
 import java.util.Calendar;
 import java.util.Date;
 
+/**
+ * @author Alex Schiff
+ */
 public abstract class AbstractTemporalBaseAnnotationHandler
     implements BeanValidationAnnotationHandler {
   protected final Date minDate;

--- a/k-random-core/pom.xml
+++ b/k-random-core/pom.xml
@@ -47,14 +47,6 @@
                 <role>Lead developer</role>
             </roles>
         </developer>
-        <developer>
-            <id>jamalkhaffaf</id>
-            <name>Jamal Khaffaf</name>
-            <url>https://github.com/jamalkhaffaf</url>
-            <roles>
-                <role>Core developer</role>
-            </roles>
-        </developer>
     </developers>
 
     <dependencies>

--- a/k-random-core/src/main/java/io/github/krandom/api/ExclusionPolicy.java
+++ b/k-random-core/src/main/java/io/github/krandom/api/ExclusionPolicy.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Field;
  * Strategy interface for field/type exclusion.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- * @since 4.0
  */
 public interface ExclusionPolicy {
 

--- a/k-random-core/src/main/java/io/github/krandom/api/ObjectFactory.java
+++ b/k-random-core/src/main/java/io/github/krandom/api/ObjectFactory.java
@@ -29,7 +29,6 @@ import io.github.krandom.ObjectCreationException;
  * Strategy interface for object creation.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- * @since 4.0
  */
 public interface ObjectFactory {
 

--- a/k-random-randomizers/pom.xml
+++ b/k-random-randomizers/pom.xml
@@ -46,14 +46,6 @@
                 <role>Lead developer</role>
             </roles>
         </developer>
-        <developer>
-            <id>jamalkhaffaf</id>
-            <name>Jamal Khaffaf</name>
-            <url>https://github.com/jamalkhaffaf</url>
-            <roles>
-                <role>Core developer</role>
-            </roles>
-        </developer>
     </developers>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -69,15 +69,6 @@
                 <role>Lead developer</role>
             </roles>
         </developer>
-        <developer>
-            <id>jamalkhaffaf</id>
-            <name>Jamal Khaffaf</name>
-            <url>https://github.com/jamalkhaffaf</url>
-            <email>jamalkhaffaf@proton.me</email>
-            <roles>
-                <role>Core developer</role>
-            </roles>
-        </developer>
     </developers>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes #44

## Proposed Changes

- Remove developer who doesn't have enough time to contribute to project
- Remove `@since` tags on javadoc comments
- Add javadoc comment to public class.